### PR TITLE
Firefox OS blockers dashboard

### DIFF
--- a/state.json
+++ b/state.json
@@ -28,6 +28,7 @@
           "http://nickdesaulniers.github.io/where-is-firefox-os/",
           "http://whattrainisitnow.com/",
           "http://people.mozilla.org/~klahnakoski/platform/releases.html#",
+          "http://charts.mozilla.org/fxos/blockers.html#project=2.1,2.2",
           "martell"
         ]
       },


### PR DESCRIPTION
Moving this into Corsica because I'm removing it from the SF display to put up corsica "ambient" instead