### PR TITLE
add FFX campaign teaser to ambient screens

### DIFF
--- a/state.json
+++ b/state.json
@@ -27,7 +27,8 @@
           "http://nickdesaulniers.github.io/where-is-firefox-os/",
           "http://whattrainisitnow.com/",
           "http://people.mozilla.org/~klahnakoski/platform/releases.html#",
-          "martell"
+          "martell",
+          "http://people.mozilla.org/~jlin/ambient/FFx_Campaign-Teaser_1920x1080_Render-Orange_1.mp4"
         ]
       },
       {


### PR DESCRIPTION
I'm working with Chelsea Novak to add a FFx campaign teaser video to show on ambient screens that use moz-corsica - this video will be removed after the campaign in June 2015 (the teaser has a date in it at the end)

I tested the video in a local instance and it autoplays on Firefox 38.0.5