### PR TITLE
Add office variant of crash graphs

### DIFF
--- a/state.json
+++ b/state.json
@@ -27,6 +27,7 @@
           "https://moz-webqa.herokuapp.com/",
           "https://moz-referrals.herokuapp.com/",
           "http://people.mozilla.org/~klahnakoski/platform/releases.html#",
+          "https://arewestableyet.com/office",
           "https://www.flickr.com/photos/134774698@N08/sets/72157655704455571 bg=#000000",
           "martell"
         ]


### PR DESCRIPTION
This displays the "crashes / 100 ADI" graph of a random channel (nightly, aurora, beta, release) and product (Firefox desktop or Firefox for Android). Currently this is limited to the recent year of data. Please direct any feedback and suggestions to KaiRo, happy to improve on this!