### PR TITLE
Added release health dashboards for all channels

### DIFF
--- a/state.json
+++ b/state.json
@@ -25,7 +25,10 @@
           "https://moz-webqa.herokuapp.com/",
           "https://moz-referrals.herokuapp.com/",
           "http://people.mozilla.org/~klahnakoski/platform/releases.html#",
-          "http://lmandel.github.io/ReleaseHealth/?channel=beta",
+          "http://lmandel.github.io/ReleaseHealth/?channel=nightly&display=bigscreen",
+          "http://lmandel.github.io/ReleaseHealth/?channel=aurora&display=bigscreen",
+          "http://lmandel.github.io/ReleaseHealth/?channel=beta&display=bigscreen",
+          "http://lmandel.github.io/ReleaseHealth/?channel=release&display=bigscreen"
           "https://arewestableyet.com/office zoom=160",
           "https://www.flickr.com/photos/134774698@N08/sets/72157662496585105 bg=#000000",
           "martell",


### PR DESCRIPTION
Added release health dashboards for all channels to ambient display. Missed this in earlier pull request for platform.