### PR TITLE
Update releasehealth dashboard for repo move

### DIFF
--- a/state.json
+++ b/state.json
@@ -25,8 +25,8 @@
           "https://moz-webqa.herokuapp.com/",
           "https://moz-referrals.herokuapp.com/",
           "http://people.mozilla.org/~klahnakoski/platform/releases.html#",
-          "http://lmandel.github.io/ReleaseHealth/?channel=aurora&display=bigscreen",
-          "http://lmandel.github.io/ReleaseHealth/?channel=beta&display=bigscreen",
+          "http://mozilla.github.io/releasehealth/?channel=aurora&display=bigscreen",
+          "http://mozilla.github.io/releasehealth/?channel=beta&display=bigscreen",
           "https://arewestableyet.com/office zoom=160",
           "martell",
           "https://plot.ly/~letsencrypt/9.embed zoom=200"
@@ -102,10 +102,10 @@
           "https://crash-analysis.mozilla.com/rkaiser/crash-report-tools/longtermgraph/?andbeta zoom=200",
           "https://docs.google.com/spreadsheets/d/1-IHoas3yLl--s_VTIin6e3hwwHZPuBWpTG_x-CCCmR4/pubhtml?gid=1851324103&single=true zoom=250",
           "people.mozilla.org/~klahnakoski/platform/releases.html#",
-          "http://lmandel.github.io/ReleaseHealth/?channel=nightly&display=bigscreen",
-          "http://lmandel.github.io/ReleaseHealth/?channel=aurora&display=bigscreen",
-          "http://lmandel.github.io/ReleaseHealth/?channel=beta&display=bigscreen",
-          "http://lmandel.github.io/ReleaseHealth/?channel=release&display=bigscreen"
+          "http://mozilla.github.io/releasehealth/?channel=nightly&display=bigscreen",
+          "http://mozilla.github.io/releasehealth/?channel=aurora&display=bigscreen",
+          "http://mozilla.github.io/releasehealth/?channel=beta&display=bigscreen",
+          "http://mozilla.github.io/releasehealth/?channel=release&display=bigscreen"
         ]
       },
       {


### PR DESCRIPTION
The releasehealth repo has moved to the Mozilla account on GitHub. Need to update the URLs in Corsica.