### PR TITLE
Switch to HTTPS content where supported

### DIFF
--- a/state.json
+++ b/state.json
@@ -33,8 +33,7 @@
       {
         "name": "airmo",
         "commands": [
-          "rss url=https://air.mozilla.org/feed/corsica/public/webm item=random",
-          "http://people.mozilla.org/~jlin/ambient/FFx_Campaign-Teaser_1920x1080_Render-Orange_1.mp4"
+          "rss url=https://air.mozilla.org/feed/corsica/public/webm item=random"
         ]
       },
       {

--- a/state.json
+++ b/state.json
@@ -20,14 +20,14 @@
         "name": "ambient",
         "commands": [
           "https://whats-shipping.herokuapp.com/dashboard",
-          "http://people.mozilla.org/~klahnakoski/platform/releases.html#",
-          "http://mozilla.github.io/releasehealth/?channel=aurora&display=bigscreen comment=\"Aurora Blockers\"",
-          "http://mozilla.github.io/releasehealth/?channel=beta&display=bigscreen comment=\"Beta Blockers\"",
+          "https://people-mozilla.org/~klahnakoski/platform/releases.html#",
+          "https://mozilla.github.io/releasehealth/?channel=aurora&display=bigscreen comment=\"Aurora Blockers\"",
+          "https://mozilla.github.io/releasehealth/?channel=beta&display=bigscreen comment=\"Beta Blockers\"",
           "https://letsencrypt.org/stats-dashboard/ zoom=190",
           "https://health.graphics/quantum?r1 zoom=125",
-          "http://mozilla.github.io/signage/posters.html comment=\"Testing Posters\"",
+          "https://mozilla.github.io/signage/posters.html comment=\"Testing Posters\"",
           "gslide id=1_deLC4RtSmMBLULJNfIv3FwG1QwnL9xkjN62ne4gbVk comment=\"Our Journey\"",
-          "http://mozilla.github.io/signage/data-classification.png comment=\"Data Classification\""
+          "https://mozilla.github.io/signage/data-classification.png comment=\"Data Classification\""
         ]
       },
       {
@@ -48,7 +48,7 @@
           "content type=html comment=\"Whimsycorn\" content=\"<style>@keyframes AnimationName{0%{background-position:center,100vw 50%}100%{background-position:center,0vw 50%}}body{background:url(https://raw.githubusercontent.com/bwinton/whimsy/f8c52e336233897ba37aa265e2fccdaa008a2ca1/wheeeeee.png)no-repeat center,linear-gradient(to right,red 0%,orange 17vw,yellow 33vw,#0f0 50vw,blue 67vw,violet 83vw,red 100vw);height:100%;background-size:90vh,cover;margin:0;animation:AnimationName 180s linear infinite;}</style><body>\"",
           "http://xor.lonnen.com/haneke-2/",
           "http://micropipes.com/temp/",
-          "http://www.google.com/trends/hottrends/visualize?nrow=3&ncol=3"
+          "https://trends.google.com/trends/hottrends/visualize?nrow=3&ncol=3"
         ]
       },
       {
@@ -66,32 +66,32 @@
       {
         "name": "mtv",
         "commands": [
-          "http://forecast.io/embed/#lat=37.3874&lon=-122.0602&name=Mozilla%20Mountain%20View&color=#E66000 zoom=300 comment=\"Mountain View Weather\"",
-          "http://moz-menu-mv.herokuapp.com/ comment=\"MV Lunch Menu\"",
+          "https://forecast.io/embed/#lat=37.3874&lon=-122.0602&name=Mozilla%20Mountain%20View&color=#E66000 zoom=300 comment=\"Mountain View Weather\"",
+          "https://moz-menu-mv.herokuapp.com/ comment=\"MV Lunch Menu\"",
           "https://moz-commute.herokuapp.com/ comment=\"MV Traffic & Transit\""
         ]
       },
       {
         "name": "pdx-eng",
         "commands": [
-          "http://i.imgur.com/XZz3CDA.png comment=\"Firefox Developer Edition logo, 16:9 version\"",
-          "http://i.imgur.com/ns5T4de.png comment=\"Firefox Nightly logo, 16:9 version\"",
-          "http://originaldave77.files.wordpress.com/2013/03/wallpaper-2015-portland-super-mario-3-map-trimet-max-2014-dave-delisle-wallpaper2.jpg comment=\"Super Mario 3-themed Trimet map\"",
-          "content type=html content=\"<body style='height:100%;background:linear-gradient(#EAEFF2,#D4DDE4)'><iframe style='border:0;position:absolute;top:50%;left:50%;height:50%;width:30vw;height:30vh;transform:translate(-50%,-50%) scale(3);' src='http://forecast.io/embed/#lat=45.5236&lon=-122.68352&name=Mozilla Portland&color=#E66000'>\"",
-          "content type=html content=\"<body style='height:100%;background:linear-gradient(#EAEFF2,#D4DDE4)'><iframe style='border:0;position:absolute;top:50%;left:50%;height:50%;width:30vw;height:30vh;transform:translate(-50%,-50%) scale(3);' src='http://forecast.io/embed/#lat=45.5236&lon=-122.68352&name=Mozilla%20Portland%20%28Celsius%29&color=#E66000&units=ca'>\"",
-          "http://i.imgur.com/yhuHkcx.gif",
+          "https://i.imgur.com/XZz3CDA.png comment=\"Firefox Developer Edition logo, 16:9 version\"",
+          "https://i.imgur.com/ns5T4de.png comment=\"Firefox Nightly logo, 16:9 version\"",
+          "https://originaldave77.files.wordpress.com/2013/03/wallpaper-2015-portland-super-mario-3-map-trimet-max-2014-dave-delisle-wallpaper2.jpg comment=\"Super Mario 3-themed Trimet map\"",
+          "content type=html content=\"<body style='height:100%;background:linear-gradient(#EAEFF2,#D4DDE4)'><iframe style='border:0;position:absolute;top:50%;left:50%;height:50%;width:30vw;height:30vh;transform:translate(-50%,-50%) scale(3);' src='https://forecast.io/embed/#lat=45.5236&lon=-122.68352&name=Mozilla%20Portland&color=#E66000'>\"",
+          "content type=html content=\"<body style='height:100%;background:linear-gradient(#EAEFF2,#D4DDE4)'><iframe style='border:0;position:absolute;top:50%;left:50%;height:50%;width:30vw;height:30vh;transform:translate(-50%,-50%) scale(3);' src='https://forecast.io/embed/#lat=45.5236&lon=-122.68352&name=Mozilla%20Portland%20%28Celsius%29&color=#E66000&units=ca'>\"",
+          "https://i.imgur.com/yhuHkcx.gif",
           "http://whattrainisitnow.com/",
           "https://ci.us-west.moz.works/view/Bedrock%20Pipeline/?fullscreen=true",
           "https://p.datadoghq.com/sb/279ea5216-630e79664d?tv_mode=true",
           "https://arewestableyet.com/office",
-          "http://i.imgur.com/SsrTV6W.png comment=\"Data Classification\""
+          "https://i.imgur.com/SsrTV6W.png comment=\"Data Classification\""
         ]
       },
       {
           "name": "paris",
           "commands": [
-              "http://vianavigo.com/fr/actualites-trafic/",
-              "http://people.mozilla.org/~sledru/station.html zoom=175"
+              "https://vianavigo.com/fr/actualites-trafic/",
+              "https://people-mozilla.org/~sledru/station.html zoom=175"
         ]
       },
       {
@@ -100,21 +100,21 @@
           "https://health.graphics/crashes zoom=150",
           "https://health.graphics/crashes/beta zoom=150",
           "https://health.graphics/quantum/countdown zoom=150",
-          "http://mozilla.github.io/releasehealth/?channel=beta&display=bigscreen",
-          "http://mozilla.github.io/releasehealth/?channel=release&display=bigscreen"
+          "https://mozilla.github.io/releasehealth/?channel=beta&display=bigscreen",
+          "https://mozilla.github.io/releasehealth/?channel=release&display=bigscreen"
         ]
       },
       {
         "name": "avops",
         "commands": [
           "http://airmozilla-ops1.corpdmz.scl3.mozilla.com/wowza/",
-          "http://moz-chargers.herokuapp.com/"
+          "https://moz-chargers.herokuapp.com/"
         ]
       },
       {
         "name": "tor",
         "commands": [
-          "content type=html content=\"<body style='height:100%;background:linear-gradient(#EAEFF2,#D4DDE4)'><iframe style='border:0;position:absolute;top:50%;left:50%;height:50%;width:30vw;height:30vh;transform:translate(-50%,-50%) scale(3);' src='http://forecast.io/embed/#lat=43.6474&lon=-79.3942&name=Mozilla Toronto&units=ca&color=#E66000'>\"",
+          "content type=html content=\"<body style='height:100%;background:linear-gradient(#EAEFF2,#D4DDE4)'><iframe style='border:0;position:absolute;top:50%;left:50%;height:50%;width:30vw;height:30vh;transform:translate(-50%,-50%) scale(3);' src='https://forecast.io/embed/#lat=43.6474&lon=-79.3942&name=Mozilla%20Toronto&units=ca&color=#E66000'>\"",
           "http://cdn.torontolife.com/wp-content/uploads/2015/10/jose-bautista-bat-02-flip.gif"
         ]
       },


### PR DESCRIPTION
Many of the HTTP URLs also work over HTTPS (or already 301 redirect to the HTTPS URL).

This PR switches all that URLs that were found to work, plus avoids some additional unnecessary redirects for existing HTTPS URLs. A page that 404s has also been removed.

The remaining pages that don't work over HTTPS are:
http://xor.lonnen.com/haneke-2/
http://micropipes.com/temp/
http://whattrainisitnow.com/
http://airmozilla-ops1.corpdmz.scl3.mozilla.com/wowza/
http://cdn.torontolife.com/wp-content/uploads/2015/10/jose-bautista-bat-02-flip.gif