### PR TITLE
Change Aurora regression page to Nightly

### DIFF
--- a/state.json
+++ b/state.json
@@ -21,7 +21,7 @@
         "commands": [
           "https://whats-shipping.herokuapp.com/dashboard",
           "https://people-mozilla.org/~klahnakoski/platform/releases.html#",
-          "https://mozilla.github.io/releasehealth/?channel=aurora&display=bigscreen comment=\"Aurora Blockers\"",
+          "https://mozilla.github.io/releasehealth/?channel=nightly&display=bigscreen comment=\"Nightly Blockers\"",
           "https://mozilla.github.io/releasehealth/?channel=beta&display=bigscreen comment=\"Beta Blockers\"",
           "https://letsencrypt.org/stats-dashboard/ zoom=190",
           "https://mozilla.github.io/signage/posters.html comment=\"Testing Posters\"",


### PR DESCRIPTION
Changed the Aurora regression page to show Nightly in response to changes with project Dawn.