### PR TITLE
Move to whattrainisitnow.com instead of whats-shipping

### DIFF
--- a/state.json
+++ b/state.json
@@ -19,7 +19,7 @@
       {
         "name": "ambient",
         "commands": [
-          "https://whats-shipping.herokuapp.com/dashboard",
+          "http://www.whattrainisitnow.com",
           "https://people-mozilla.org/~klahnakoski/platform/releases.html#",
           "https://mozilla.github.io/releasehealth/?channel=nightly&display=bigscreen comment=\"Nightly Blockers\"",
           "https://mozilla.github.io/releasehealth/?channel=beta&display=bigscreen comment=\"Beta Blockers\"",


### PR DESCRIPTION
I don't know why https://github.com/mozilla/moz-corsica/pull/84 was closed.
Doing a PR in case I convinced you in PR #84 