### PR TITLE
add tpe-lab tag and content for Hasal team

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You can choose from the following **tags** for your screen:
 * `ldn` (London)
 * `yvr` (Vancouver)
 * `tpe` (Taipei)
+* `tpe-lab` (Taipei Hasal Lab)
 
 Most office displays are set to at least `ambient`, and often also `whimsy`.
 

--- a/state.json
+++ b/state.json
@@ -134,6 +134,24 @@
         ]
       },
       {
+        "name": "tpe-lab",
+        "commands": [
+          "https://mozilla-twqa.github.io/Hasal_dashboard/amazon_windows8-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/facebook1_windows8-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/facebook2_windows8-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/gdoc_gsearch_windows8-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/gmail_windows8-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/youtube_windows8-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/amazon_windows10-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/facebook1_windows10-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/facebook2_windows10-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/gdoc_gsearch_windows10-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/gmail_windows10-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/youtube_windows10-64_set.html",
+          "https://mozilla-twqa.github.io/Hasal_dashboard/daily_progress_all.html"
+        ]
+      },
+      {
         "name": "ldn",
         "commands": [
         ]


### PR DESCRIPTION
Hi~ I'm Mark, a student worker in Mozilla Taipei Office. I am working in Hasal team, which conducts some speed testing on Firefox and Chrome.

I created some web pages as the dashboard to present our team's testing progress. We would like to combine those pages into your system. Therefore, we can display the content with your project on the TV in our Taipei lab.