### PR TITLE
adds releng release status dashboard of desktop releases in flight

### DIFF
--- a/state.json
+++ b/state.json
@@ -29,7 +29,8 @@
           "gslide comment=\"dec5\" to=2017-12-01 id=1ne7_BZDD5W1o0suyNbNQp6fdKZmbZwP02InPRIgm9pY",
           "https://health.graphics/quantum?full=1 zoom=150",
           "https://andymckay.github.io/mozilla-strava/ zoom=175",
-          "https://quantum-soon.glitch.me/ comment=\"quantum suit take off\""
+          "https://quantum-soon.glitch.me/ comment=\"quantum suit take off\"",
+          "https://mozilla-releng.github.io/releasewarrior-data"
         ]
       },
       {
@@ -37,7 +38,8 @@
         "commands": [
           "https://fx-topline-release-dash.herokuapp.com/?office-tv",
           "https://quantum-soon.glitch.me/",
-          "https://quantum-launch-horse.herokuapp.com/"
+          "https://quantum-launch-horse.herokuapp.com/",
+          "https://mozilla-releng.github.io/releasewarrior-data"
         ]
       },
       {


### PR DESCRIPTION
releng's release tracking tool now exports a dashboard for corsica, hoping to add it to rotation.

I wasn't sure where to update state.json.