### PR TITLE
Convert sites to HTTPS

### DIFF
--- a/state.json
+++ b/state.json
@@ -62,7 +62,7 @@
                 "commands": [
                     "content type=html comment=\"Whimsycorn\" content=\"<style>@keyframes AnimationName{0%{background-position:center,100vw 50%}100%{background-position:center,0vw 50%}}body{background:url(https://raw.githubusercontent.com/bwinton/whimsy/f8c52e336233897ba37aa265e2fccdaa008a2ca1/wheeeeee.png)no-repeat center,linear-gradient(to right,red 0%,orange 17vw,yellow 33vw,#0f0 50vw,blue 67vw,violet 83vw,red 100vw);height:100%;background-size:90vh,cover;margin:0;animation:AnimationName 180s linear infinite;}</style><body>\"",
                     "https://micropipes.com/temp/",
-		    "https://trends.google.com/trends/hottrends/visualize?nrow=3&ncol=3"
+                    "https://trends.google.com/trends/hottrends/visualize?nrow=3&ncol=3"
                 ]
             },
             {

--- a/state.json
+++ b/state.json
@@ -61,7 +61,8 @@
                 "name": "whimsy",
                 "commands": [
                     "content type=html comment=\"Whimsycorn\" content=\"<style>@keyframes AnimationName{0%{background-position:center,100vw 50%}100%{background-position:center,0vw 50%}}body{background:url(https://raw.githubusercontent.com/bwinton/whimsy/f8c52e336233897ba37aa265e2fccdaa008a2ca1/wheeeeee.png)no-repeat center,linear-gradient(to right,red 0%,orange 17vw,yellow 33vw,#0f0 50vw,blue 67vw,violet 83vw,red 100vw);height:100%;background-size:90vh,cover;margin:0;animation:AnimationName 180s linear infinite;}</style><body>\"",
-                    "https://trends.google.com/trends/hottrends/visualize?nrow=3&ncol=3"
+                    "https://micropipes.com/temp/",
+		    "https://trends.google.com/trends/hottrends/visualize?nrow=3&ncol=3"
                 ]
             },
             {

--- a/state.json
+++ b/state.json
@@ -61,7 +61,6 @@
                 "name": "whimsy",
                 "commands": [
                     "content type=html comment=\"Whimsycorn\" content=\"<style>@keyframes AnimationName{0%{background-position:center,100vw 50%}100%{background-position:center,0vw 50%}}body{background:url(https://raw.githubusercontent.com/bwinton/whimsy/f8c52e336233897ba37aa265e2fccdaa008a2ca1/wheeeeee.png)no-repeat center,linear-gradient(to right,red 0%,orange 17vw,yellow 33vw,#0f0 50vw,blue 67vw,violet 83vw,red 100vw);height:100%;background-size:90vh,cover;margin:0;animation:AnimationName 180s linear infinite;}</style><body>\"",
-                    "http://micropipes.com/temp/",
                     "https://trends.google.com/trends/hottrends/visualize?nrow=3&ncol=3"
                 ]
             },
@@ -93,7 +92,7 @@
                     "https://originaldave77.files.wordpress.com/2013/03/wallpaper-2015-portland-super-mario-3-map-trimet-max-2014-dave-delisle-wallpaper2.jpg comment=\"Super Mario 3-themed Trimet map\"",
                     "content type=html content=\"<body style='height:100%;background:linear-gradient(#EAEFF2,#D4DDE4)'><iframe style='border:0;position:absolute;top:50%;left:50%;height:50%;width:30vw;height:30vh;transform:translate(-50%,-50%) scale(3);' src='https://forecast.io/embed/#lat=45.5236&lon=-122.68352&name=Mozilla%20Portland&color=#E66000'>\"",
                     "https://i.imgur.com/yhuHkcx.gif",
-                    "http://whattrainisitnow.com/",
+                    "https://whattrainisitnow.com/",
                     "https://p.datadoghq.com/sb/279ea5216-630e79664d?tv_mode=true",
                     "https://i.imgur.com/SsrTV6W.png comment=\"Data Classification\"",
                     "https://mythmon.github.io/corsica-tree-status/",
@@ -107,7 +106,7 @@
                     "https://originaldave77.files.wordpress.com/2013/03/wallpaper-2015-portland-super-mario-3-map-trimet-max-2014-dave-delisle-wallpaper2.jpg comment=\"Super Mario 3-themed Trimet map\"",
                     "content comment=\"weather\" type=html content=\"<body style='height:100%;background:linear-gradient(#EAEFF2,#D4DDE4)'><iframe style='border:0;position:absolute;top:50%;left:50%;height:50%;width:30vw;height:30vh;transform:translate(-50%,-50%) scale(3);' src='https://forecast.io/embed/#lat=45.5236&lon=-122.68352&name=Mozilla%20Portland&color=#E66000'>\"",
                     "https://i.imgur.com/yhuHkcx.gif comment=\"Multnomah falls\"",
-                    "http://whattrainisitnow.com/",
+                    "https://whattrainisitnow.com/",
                     "https://trimet.org/onsite/multi_stop_arrivals.html?locationIDs=10791,10792,1607,10756,10770&byRoute"
                 ]
             },
@@ -130,7 +129,7 @@
             {
                 "name": "avops",
                 "commands": [
-                    "http://airmozilla-ops1.corpdmz.scl3.mozilla.com/wowza/",
+                    "https://airmozilla-ops1.corpdmz.scl3.mozilla.com/wowza/",
                     "https://moz-chargers.herokuapp.com/"
                 ]
             },
@@ -138,7 +137,7 @@
                 "name": "tor",
                 "commands": [
                     "content type=html content=\"<body style='height:100%;background:linear-gradient(#EAEFF2,#D4DDE4)'><iframe style='border:0;position:absolute;top:50%;left:50%;height:50%;width:30vw;height:30vh;transform:translate(-50%,-50%) scale(3);' src='https://forecast.io/embed/#lat=43.6474&lon=-79.3942&name=Mozilla%20Toronto&units=ca&color=#E66000'>\"",
-                    "http://cdn.torontolife.com/wp-content/uploads/2015/10/jose-bautista-bat-02-flip.gif"
+                    "https://cdn.torontolife.com/wp-content/uploads/2015/10/jose-bautista-bat-02-flip.gif"
                 ]
             },
             {
@@ -179,14 +178,13 @@
                     "https://forecast.io/embed/#lat=52.499&lon=13.4491&units=ca&name=Berlin%20Kreuzberg zoom=300 comment=\"Berlin Kreuzberg Weather\"",
                     "https://d3vv6lp55qjaqc.cloudfront.net/items/2a1J2x1x201d1K2f2C1d/firefox-nightly-wallpaper-1920x1080.png comment=\"Firefox Nightly logo, 16:9 version\"",
                     "gslide id=1jZIJj_3swsUzATpPO9HN3ZWm6deY8hE5sEF9GlfjfXs comment=\"Berlin office events\"",
-                    "gslide id=1I5CqL2zWUcAG535J769oADif_AiN4_43Kx8QscAtxbQ comment=\"Internet health jeopardy\"",
-                    "http://emanueladamiani.com/photon/welcome-june.jpg comment=\"Welcome new hires\""
+                    "gslide id=1I5CqL2zWUcAG535J769oADif_AiN4_43Kx8QscAtxbQ comment=\"Internet health jeopardy\""
                 ]
             },
             {
                 "name": "berlin-fun",
                 "commands": [
-                    "http://i.imgur.com/xQeUIME.jpg"
+                    "https://i.imgur.com/xQeUIME.jpg"
                 ]
             }
         ]


### PR DESCRIPTION
Changed sites that were listed as HTTP to HTTPS, to unblock https://github.com/mozilla/dinobuildr/pull/107. Removed two sites that appear to not support HTTPS