### PR TITLE
Removed decommissioned avops command.

### DIFF
--- a/state.json
+++ b/state.json
@@ -130,7 +130,6 @@
             {
                 "name": "avops",
                 "commands": [
-                    "https://airmozilla-ops1.corpdmz.scl3.mozilla.com/wowza/",
                     "https://moz-chargers.herokuapp.com/"
                 ]
             },


### PR DESCRIPTION
Checked with the avops team. They no longer need https://airmozilla-ops1.corpdmz.scl3.mozilla.com/wowza/.