### PR TITLE
No longer using releasewarrior to track releases, remove stale data source from corsica

### DIFF
--- a/state.json
+++ b/state.json
@@ -26,7 +26,6 @@
                     "https://mozilla.github.io/signage/data-classification.png comment=\"Data Classification\"",
                     "https://are-we-triaged-yet.herokuapp.com/?version=65&report=untriaged comment=\"Beta Triage\"",
                     "https://are-we-triaged-yet.herokuapp.com/?version=66&report=untriaged comment=\"Nightly Triage\"",
-                    "https://mozilla-releng.github.io/releasewarrior-data comment=\"release tracking\"",
                     "gslide id=1p0XUsA6jh6Ck_1zcQGznMaO8uO0p__iuRhEDp9cj1EA comment=\"nice tweets\"",
                     "https://bgrins.github.io/xbl-analysis/graph/#burndown zoom=180 comment=\"XBL Burndown\""
                 ]


### PR DESCRIPTION
We are no longer using releasewarrior-data for new release tracking, so we shouldn't use that as a source in corsica for office monitors.

The new place we are using doesn't yet have this data accessible from outside VPN so hold off on adding it in.