### PR TITLE
Remove lunch slide from MTV tag

### DIFF
--- a/state.json
+++ b/state.json
@@ -92,7 +92,6 @@
                 "random": true,
                 "commands": [
                     "https://forecast.io/embed/#lat=37.3874&lon=-122.0602&name=Mozilla%20Mountain%20View&color=#E66000 zoom=300 comment=\"Mountain View Weather\"",
-                    "https://moz-menu-mv.glitch.me/ comment=\"MV Lunch Menu\"",
                     "https://moz-commute-mv.glitch.me/ comment=\"MV Traffic & Transit\"",
                     "https://estimated-prophet.glitch.me/ comment=\"West Coast from Space\""
                 ]


### PR DESCRIPTION
Filing on behalf of Abbie Woods to remove the lunch slide from the MTV corsica tag (mtv only).

Thanks!