### PR TITLE
Change Fission status page from M4 tests to M5 bugs

### DIFF
--- a/state.json
+++ b/state.json
@@ -29,7 +29,7 @@
                     "https://arewetriagedyet.net/?report=untriaged comment=\"Triage Status\"",
                     "gslide id=1faZ-uoAd3Zg7voYM90GxAM7BFqn4xPcKxb88ws9HHQs comment=\"nice tweets\"",
                     "https://www.whatrustisit.com",
-                    "https://arewefissionyet.com/m4/?dashboard zoom=200 comment=\"Fission Milestone 4 Burndown\"",
+                    "https://cpeterso.github.io/burndown/?cf_fission_milestone=M5&since=2019-11-18 zoom=170 comment=\"Fission Dogfooding (M5) Bugs\"",
                     "https://arewefluentyet.com/?milestone=M1&dashboard=1",
                     "https://arewefluentyet.com/?milestone=M3&dashboard=1",
                     "gslide id=1CnHrwSk9trcjdKinu5Nv8mfd_rn9qkX0cj1rqg74eF8 comment=\"DUO Enrollment\""


### PR DESCRIPTION
Fission's M5 milestone tracks the bugs blocker internal dogfood testing of Fission. Engineering management feels the M5 bug chart shows more meaningful progress than the M4.1 test chart.

Note that I don't know how to actually test this change (or zoom level) before submitting it here... 😟

@bgrins added the original Fission status page to Corsica in #171.