### PR TITLE
removed moz-chargers

### DIFF
--- a/state.json
+++ b/state.json
@@ -152,7 +152,6 @@
                 "name": "avops",
                 "random": true,
                 "commands": [
-                    "https://moz-chargers.herokuapp.com/"
                 ]
             },
             {


### PR DESCRIPTION
I've shut down the moz-chargers herokuapp and this will remove it from the list. The source is saved and on github if we want to restart it on glitch or some other service