### PR TITLE
add configuration for github ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+# Github Actions CI config
+
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - run: ./script/cibuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: no
-language: node_js
-node_js:
-- '4.7.3'
-- '7.5.0'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 moz-corsica
 ===========
 
+[![Build Status](https://github.com/mozilla/moz-corsica/actions/workflows/ci.yml/badge.svg)]
+
 Public Corsica instance for Mozilla office and home offices.
 
 If you are at a Mozilla office, this project is what powers the content

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 moz-corsica
 ===========
 
-[![Build Status](https://travis-ci.org/mozilla/moz-corsica.svg)](https://travis-ci.org/mozilla/moz-corsica)
-
 Public Corsica instance for Mozilla office and home offices.
 
 If you are at a Mozilla office, this project is what powers the content
@@ -29,7 +27,7 @@ and we can remotely configure the screen.
 Alternatively, you can manually configure a window by open the Web Console (Tools-> Web Developer-> Web Console) and run the following commands, substituting your preferred values for name and tags:
 
 ```javascript
-config.name = "$the-desired-name"; 
+config.name = "$the-desired-name";
 config.tags = ["ambient"];
 writeConfig();
 ```

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-npm install
+npm ci # clean install


### PR DESCRIPTION
fixes issue #195 by introducing the configuration necessary to run CI on Github Actions. This also moves to a supported version of node and swaps out 'npm install' for the newly available 'clean install' which is actually what we want in a CI environment.