### PR TITLE
remove winston, forever

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,7 @@
         "corsica-tweet": "^2.0.0",
         "corsica-video": "^0.3.4",
         "corsica-xkcd": "^0.5.0",
-        "corsica-youtube": "^0.1.0",
-        "forever": "^3.0.4",
-        "winston": "^0.7.3"
+        "corsica-youtube": "^0.1.0"
       }
     },
     "node_modules/@types/component-emitter": {
@@ -6315,8 +6313,7 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/forever/-/forever-3.0.4.tgz",
+      "version": "https://registry.npmjs.org/forever/-/forever-3.0.4.tgz",
       "integrity": "sha512-MZDQu9nxVavSOez+k0MGdoe9/0tGN/QfAj3Xn8OjJbRYlLghq/3isf5c2xt280x04EVKguU9/tmLE74259Xazw==",
       "requires": {
         "async": "^1.5.2",
@@ -8531,8 +8528,7 @@
       "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "winston": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
+      "version": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
       "integrity": "sha1-euMTunP83C7LSqL5zURugphncmY=",
       "requires": {
         "async": "0.2.x",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "corsica-tweet": "^2.0.0",
     "corsica-video": "^0.3.4",
     "corsica-xkcd": "^0.5.0",
-    "corsica-youtube": "^0.1.0",
-    "forever": "^3.0.4",
-    "winston": "^0.7.3"
+    "corsica-youtube": "^0.1.0"
   }
 }


### PR DESCRIPTION
can't figure out where these are used. seems to be copied in from an unmanaged environment

```shell
[22:00:41] $ grep -r --exclude-dir=node_modules --exclude=package-lock.json winston *
package.json:    "winston": "^0.7.3"
```

```shell
[22:01:22] $ grep -r --exclude-dir=node_modules --exclude=package-lock.json forever *
package.json:    "forever": "^3.0.4"
```