### PR TITLE
remove unimported plugins from the environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-plugins=["brain","settings","proxy","census","command","content","glob","namer","tags","timer","corsica-xkcd","corsica-flickr-2","corsica-image","corsica-video","corsica-rss","corsica-martell","corsica-youtube","corsica-google-presentation","corsica-irc"]
+plugins=["brain","settings","proxy","census","command","content","glob","namer","tags","timer","corsica-xkcd","corsica-flickr-2","corsica-image","corsica-video","corsica-rss","corsica-youtube","corsica-google-presentation"]
 flickr_api_key=@@SECRET@@
 flickr_secret=@@SECRET@@


### PR DESCRIPTION
We removed a few plugins from the package listing recently but they're still enumerating in the config and there is a benign error trying to load them at runtime. This cleans that up.