### PR TITLE
remove airmo, rss

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-plugins=["brain","settings","proxy","census","command","content","glob","namer","tags","timer","corsica-xkcd","corsica-flickr-2","corsica-image","corsica-video","corsica-rss","corsica-youtube","corsica-google-presentation"]
+plugins=["brain","settings","proxy","census","command","content","glob","namer","tags","timer","corsica-xkcd","corsica-flickr-2","corsica-image","corsica-video","corsica-youtube","corsica-google-presentation"]
 flickr_api_key=@@SECRET@@
 flickr_secret=@@SECRET@@

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "corsica-google-presentation": "^1.0.0",
         "corsica-image": "^0.2.2",
         "corsica-mozfund": "^1.0.0",
-        "corsica-rss": "^0.1.0",
         "corsica-tweet": "^2.0.0",
         "corsica-video": "^0.3.4",
         "corsica-xkcd": "^0.5.0",
@@ -65,10 +64,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/addressparser": {
-      "version": "0.1.3",
-      "license": "MIT"
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
@@ -85,10 +80,6 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "license": "MIT"
-    },
-    "node_modules/array-indexofobject": {
-      "version": "0.0.1",
       "license": "MIT"
     },
     "node_modules/asn1": {
@@ -373,18 +364,6 @@
     },
     "node_modules/corsica-mozfund/node_modules/es6-promise": {
       "version": "2.3.0",
-      "license": "MIT"
-    },
-    "node_modules/corsica-rss": {
-      "version": "0.1.0",
-      "license": "MPL2",
-      "dependencies": {
-        "es6-promise": "^1.0.0",
-        "feedparser": "^0.16.6"
-      }
-    },
-    "node_modules/corsica-rss/node_modules/es6-promise": {
-      "version": "1.0.0",
       "license": "MIT"
     },
     "node_modules/corsica-tweet": {
@@ -674,19 +653,6 @@
       "version": "2.1.0",
       "license": "MIT"
     },
-    "node_modules/feedparser": {
-      "version": "0.16.6",
-      "dependencies": {
-        "addressparser": "~0.1.3",
-        "array-indexofobject": "0.0.1",
-        "readable-stream": "1.0.x",
-        "resanitize": "~0.3.0",
-        "sax": "0.5.x"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.1.2",
       "license": "MIT",
@@ -857,10 +823,6 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
       "license": "MIT"
     },
     "node_modules/isstream": {
@@ -1088,16 +1050,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "1.0.34",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
     "node_modules/request": {
       "version": "2.88.2",
       "license": "Apache-2.0",
@@ -1134,16 +1086,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/resanitize": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "validator": "~1.5.1"
-      },
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "license": "MIT"
@@ -1151,10 +1093,6 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "0.5.8",
-      "license": "BSD"
     },
     "node_modules/send": {
       "version": "0.17.1",
@@ -1296,10 +1234,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "license": "MIT"
-    },
     "node_modules/superagent": {
       "version": "3.8.3",
       "license": "MIT",
@@ -1429,12 +1363,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/validator": {
-      "version": "1.5.1",
-      "engines": {
-        "node": ">=0.2.2"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "license": "MIT",
@@ -1522,9 +1450,6 @@
     "acorn-walk": {
       "version": "8.1.0"
     },
-    "addressparser": {
-      "version": "0.1.3"
-    },
     "ajv": {
       "version": "6.12.6",
       "requires": {
@@ -1536,9 +1461,6 @@
     },
     "array-flatten": {
       "version": "1.1.1"
-    },
-    "array-indexofobject": {
-      "version": "0.0.1"
     },
     "asn1": {
       "version": "0.2.4",
@@ -1747,18 +1669,6 @@
         }
       }
     },
-    "corsica-rss": {
-      "version": "0.1.0",
-      "requires": {
-        "es6-promise": "^1.0.0",
-        "feedparser": "^0.16.6"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "1.0.0"
-        }
-      }
-    },
     "corsica-tweet": {
       "version": "2.0.0",
       "requires": {
@@ -1948,16 +1858,6 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0"
     },
-    "feedparser": {
-      "version": "0.16.6",
-      "requires": {
-        "addressparser": "~0.1.3",
-        "array-indexofobject": "0.0.1",
-        "readable-stream": "1.0.x",
-        "resanitize": "~0.3.0",
-        "sax": "0.5.x"
-      }
-    },
     "finalhandler": {
       "version": "1.1.2",
       "requires": {
@@ -2062,9 +1962,6 @@
     },
     "is-typedarray": {
       "version": "1.0.0"
-    },
-    "isarray": {
-      "version": "0.0.1"
     },
     "isstream": {
       "version": "0.1.2"
@@ -2196,15 +2093,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "readable-stream": {
-      "version": "1.0.34",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
     "request": {
       "version": "2.88.2",
       "requires": {
@@ -2235,20 +2123,11 @@
         }
       }
     },
-    "resanitize": {
-      "version": "0.3.0",
-      "requires": {
-        "validator": "~1.5.1"
-      }
-    },
     "safe-buffer": {
       "version": "5.1.2"
     },
     "safer-buffer": {
       "version": "2.1.2"
-    },
-    "sax": {
-      "version": "0.5.8"
     },
     "send": {
       "version": "0.17.1",
@@ -2349,9 +2228,6 @@
     "statuses": {
       "version": "1.5.0"
     },
-    "string_decoder": {
-      "version": "0.10.31"
-    },
     "superagent": {
       "version": "3.8.3",
       "requires": {
@@ -2442,9 +2318,6 @@
     },
     "uuid": {
       "version": "3.4.0"
-    },
-    "validator": {
-      "version": "1.5.1"
     },
     "vary": {
       "version": "1.1.2"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "corsica-google-presentation": "^1.0.0",
     "corsica-image": "^0.2.2",
     "corsica-mozfund": "^1.0.0",
-    "corsica-rss": "^0.1.0",
     "corsica-tweet": "^2.0.0",
     "corsica-video": "^0.3.4",
     "corsica-xkcd": "^0.5.0",

--- a/state.json
+++ b/state.json
@@ -49,13 +49,6 @@
                 ]
             },
             {
-                "name": "airmo",
-                "random": true,
-                "commands": [
-                    "rss url=https://air.mozilla.org/feed/corsica/public/webm item=random"
-                ]
-            },
-            {
                 "name": "cookies",
                 "random": true,
                 "commands": [
@@ -150,8 +143,7 @@
             {
                 "name": "avops",
                 "random": true,
-                "commands": [
-                ]
+                "commands": []
             },
             {
                 "name": "tor",


### PR DESCRIPTION
the airmo screens group is empty and the playlist item hasn't worked since the cutover to onlineexperiences. There is a redirect but it loads an empty document. This change removes the playlist, the plugin from the environment, and the package as a dependency